### PR TITLE
Add QuickNotes plugin to third-party Run plugins documentation

### DIFF
--- a/doc/thirdPartyRunPlugins.md
+++ b/doc/thirdPartyRunPlugins.md
@@ -43,6 +43,7 @@ Contact the developers of a plugin directly for assistance with a specific plugi
 | [TailwindCSS](https://github.com/skttl/ptrun-tailwindcss) | [skttl](https://github.com/skttl) | Search the documentation of TailwindCSS |
 | [HttpStatusCodes](https://github.com/grzhan/HttpStatusCodePowerToys) | [grzhan](https://github.com/grzhan) | Search for http status codes |
 | [SVGL](https://github.com/Sameerjs6/powertoys-svgl) | [SameerJS6](https://github.com/SameerJS6) | Search, Browse and copy SVG logos from SVGL. |
+| [QuickNotes](https://github.com/ruslanlap/CommunityPowerToysRunPlugin-QuickNotes) | [ruslanlap](https://github.com/ruslanlap) | Create, manage, and search notes directly from PowerToys Run. |
 
 ## Extending software plugins
 


### PR DESCRIPTION
QuickNotes is a plugin for Microsoft PowerToys Run that allows you to quickly create, manage, and search notes directly from your PowerToys Run interface. Simply type qq followed by your note text to save it, or use various commands to manage your notes collection.
✨ Features

    📝 Quick Note Creation - Instantly save notes with a simple command
    🔍 Powerful Search - Find notes with highlighted search terms
    🏷️ Tag Support - Add #tags to notes and search by tag
    📌 Pin Important Notes - Pin critical notes to keep them at the top
    🔄 Sorting Options - Sort notes by date or alphabetically
    ✏️ Easy Editing - Modify existing notes with a simple interface
    🗑️ Note Management - Delete individual notes or clear all notes
    ↩️ Undo Delete - Restore recently deleted notes
    💾 Backup & Export - Create backups of your notes collection
    📋 Clipboard Integration - Copy notes to clipboard with a single click
    🌓 Theme Support - Works with both light and dark PowerToys themes
    ⏱️ Timestamp Recording - Each note is saved with a timestamp for easy reference
    🔔 Notification System - Get confirmation when notes are saved, edited, or deleted
    🔗 URL Detection - Automatically detects and allows opening URLs in notes
    ✨ Text Formatting - Format notes with Markdown-style syntax for bold, italic, and highlights
    🏷️ Customizable Tag Style - Toggle between bold or italic formatting for tags
    💡 Command Auto-suggestions - Get real-time command suggestions as you type use Tab key it's easy