### PR TITLE
[PowerToysRun][Docs] Add Weather and Pomodoro to Third-Party plugins

### DIFF
--- a/doc/thirdPartyRunPlugins.md
+++ b/doc/thirdPartyRunPlugins.md
@@ -43,6 +43,9 @@ Contact the developers of a plugin directly for assistance with a specific plugi
 | [TailwindCSS](https://github.com/skttl/ptrun-tailwindcss) | [skttl](https://github.com/skttl) | Search the documentation of TailwindCSS |
 | [HttpStatusCodes](https://github.com/grzhan/HttpStatusCodePowerToys) | [grzhan](https://github.com/grzhan) | Search for http status codes |
 | [SVGL](https://github.com/Sameerjs6/powertoys-svgl) | [SameerJS6](https://github.com/SameerJS6) | Search, Browse and copy SVG logos from SVGL. |
+| [QuickNotes](https://github.com/ruslanlap/CommunityPowerToysRunPlugin-QuickNotes) | [ruslanlap](https://github.com/ruslanlap) | Create, manage, and search notes directly from PowerToys Run. |
+| [Weather](https://github.com/ruslanlap/PowerToysRun-Weather) | [ruslanlap](https://github.com/ruslanlap) | Get real-time weather information directly from PowerToys Run. |
+| [Pomodoro](https://github.com/ruslanlap/PowerToysRun-Pomodoro) | [ruslanlap](https://github.com/ruslanlap) | Manage Pomodoro productivity sessions directly from PowerToys Run. |
 
 ## Extending software plugins
 


### PR DESCRIPTION
1. Get real-time weather information directly from PowerToys Run. Weather is a plugin for Microsoft PowerToys Run that allows you to quickly check weather conditions directly from your PowerToys Run interface. Simply type weather followed by a location to get real-time weather information, or set up favorite locations for instant access.
2. Pomodoro is a plugin for Microsoft PowerToys Run that brings the popular Pomodoro Technique to your keyboard. Simply type pomodoro followed by a command like start, pause, or status to manage your productivity sessions directly from your PowerToys Run interface.